### PR TITLE
Add translation support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,15 @@ PATH
   remote: .
   specs:
     playdate (0.0.1)
+      i18n
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    concurrent-ruby (1.1.10)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
     json (2.6.2)
     minitest (5.16.3)
     parallel (1.22.1)
@@ -35,6 +39,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   minitest (~> 5.0)

--- a/lib/playdate.rb
+++ b/lib/playdate.rb
@@ -2,9 +2,13 @@
 
 require "zeitwerk"
 require "date"
+require "i18n"
 
 loader = Zeitwerk::Loader.for_gem(warn_on_extra_files: false)
 loader.setup
+
+
+I18n.load_path += Dir[File.expand_path("playdate/locales", __dir__) + "/*.yml"]
 
 module Playdate
   class Error < StandardError; end

--- a/lib/playdate/day.rb
+++ b/lib/playdate/day.rb
@@ -1,5 +1,15 @@
 module Playdate
   class Day
+		class << self
+			def names
+				I18n.t("playdate.date.day_names")
+			end
+
+			def abbreviated_names
+				I18n.t("playdate.date.abbr_day_names")
+			end
+		end
+
 		def initialize(year:, month:, day:)
 			@date = Date.new(year, month, day)
 		end
@@ -19,7 +29,11 @@ module Playdate
 		end
 
 		def name
-			Date::DAYNAMES[@date.wday]
+			self.class.names[@date.wday]
+		end
+
+		def abbreviated_name
+			self.class.abbreviated_names[@date.wday]
 		end
 
 		def month

--- a/lib/playdate/locales/en.yml
+++ b/lib/playdate/locales/en.yml
@@ -1,0 +1,30 @@
+en:
+  playdate:
+    date:
+      formats:
+        # Use the strftime parameters for formats.
+        # When no format has been given, it uses default.
+        # You can provide other formats here if you like!
+        default: "%Y-%m-%d"
+        short: "%b %d"
+        long: "%B %d, %Y"
+
+      day_names: [Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday]
+      abbr_day_names: [Sun, Mon, Tue, Wed, Thu, Fri, Sat]
+
+      # Don't forget the nil at the beginning; there's no such thing as a 0th month
+      month_names: [~, January, February, March, April, May, June, July, August, September, October, November, December]
+      abbr_month_names: [~, Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec]
+      # Used in date_select and datetime_select.
+      order:
+        - year
+        - month
+        - day
+
+      time:
+        formats:
+          default: "%a, %d %b %Y %H:%M:%S %z"
+          short: "%d %b %H:%M"
+          long: "%B %d, %Y %H:%M"
+        am: "am"
+        pm: "pm"

--- a/lib/playdate/locales/fr.yml
+++ b/lib/playdate/locales/fr.yml
@@ -1,0 +1,28 @@
+fr:
+  playdate:
+    date:
+      formats:
+        # Use the strftime parameters for formats.
+        # When no format has been given, it uses default.
+        # You can provide other formats here if you like!
+        default: "%Y-%m-%d"
+        short: "%b %d"
+        long: "%B %d, %Y"
+
+      day_names: [Dimanche, Lundi, Mardi, Mercredi, Jeudi, Vendredi, Samedi]
+      abbr_day_names: [Dim, Lun, Mar, Mer, Jeu, Ven, Sam]
+
+      # Don't forget the nil at the beginning; there's no such thing as a 0th month
+      month_names: [~, Janvier, Fèvrier, Mars, Avril, Mai, Juin, Juillet, Août, Septembre, Octobre, Novembre, Décembre]
+      abbr_month_names: [~, Jan, Fèv, Mar, Avr, Mai, Jun, Jul, Aoû, Sep, Oct, Nov, Déc]
+      # Used in date_select and datetime_select.
+      order:
+        - year
+        - month
+        - day
+
+      time:
+        formats:
+          default: "%a, %d %b %Y %H:%M:%S %z"
+          short: "%d %b %H:%M"
+          long: "%B %d, %Y %H:%M"

--- a/lib/playdate/month.rb
+++ b/lib/playdate/month.rb
@@ -1,12 +1,22 @@
 module Playdate
 	class Month
+		class << self
+			def names
+				I18n.t("playdate.date.month_names")
+			end
+
+			def abbreviated_names
+				I18n.t("playdate.date.abbr_month_names")
+			end
+		end
+
 		attr_accessor :date
 
 		def initialize(year:, month:)
 			@date = Date.new(year, month)
 		end
 
-		Date::MONTHNAMES.each_with_index do |name, index|
+		names.each_with_index do |name, index|
 			next unless name
 			define_method("#{name.downcase}?") { to_i == index  }
 		end
@@ -40,7 +50,7 @@ module Playdate
 		end
 
 		def name
-			Date::MONTHNAMES[@date.month]
+			self.class.names[@date.month]
 		end
 
 		def month_of_year
@@ -48,7 +58,7 @@ module Playdate
 		end
 
 		def abbreviated_name
-			Date::MONTHNAMES[@date.month][0, 3]
+			self.class.abbreviated_names[@date.month]
 		end
 
 		alias_method :to_s, :name

--- a/playdate.gemspec
+++ b/playdate.gemspec
@@ -27,8 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
+  spec.add_dependency "i18n"
 
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/test/playdate/month_test.rb
+++ b/test/playdate/month_test.rb
@@ -3,6 +3,8 @@ require "playdate"
 describe Playdate::Month do
 	let(:january) { Playdate::Month.new(year: 2022, month: 01) }
 	let(:december) { Playdate::Month.new(year: 2022, month: 12) }
+	let(:february) { Playdate::Month.new(year: 2022, month: 02) }
+	let(:august) { Playdate::Month.new(year: 2022, month: 8) }
 	let(:next_january) { Playdate::Month.new(year: 2023, month: 01) }
 
 	class << self
@@ -17,6 +19,22 @@ describe Playdate::Month do
 	test "abbreviated_name" do
 		expect(january.abbreviated_name).to be == "Jan"
 		expect(december.abbreviated_name).to be == "Dec"
+	end
+
+	test "translation" do
+		I18n.locale = :fr
+
+		expect(january.name).to be == "Janvier"
+		expect(december.name).to be == "Décembre"
+		expect(february.name).to be == "Fèvrier"
+		expect(august.name).to be == "Août"
+
+		expect(january.abbreviated_name).to be == "Jan"
+		expect(december.abbreviated_name).to be == "Déc"
+		expect(february.abbreviated_name).to be == "Fèv"
+		expect(august.abbreviated_name).to be == "Aoû"
+
+		I18n.locale = :en
 	end
 
 	test "year" do


### PR DESCRIPTION
This PR uses the i18n gem to add translation support:
```ruby
year = Playdate::Year.new(year: Date.today.year)
year.months # => January 2022..December 2022
january.days.first.name # => "Sunday"

I18n.locale = :fr
year.months # => Janvier 2022..Décembre 2022
january.days.first.name => "Dimanche"
```

The `:en` locale was [copied](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/locale/en.yml#:~:text=en%3A,%22pm%22) from ActiveSupport and the `:fr` locale was added to test the behaviour.