### PR TITLE
Improve `Playdate::Week`

### DIFF
--- a/lib/playdate/week.rb
+++ b/lib/playdate/week.rb
@@ -5,15 +5,37 @@ module Playdate
 		include Relative::Years
 
 		def initialize(year:, week:)
-			@date = Date.commercial(year, week)
+			@date = Date.strptime("#{year}-#{week}", "%Y-%W")
+		rescue
+			case week
+			when 0
+				@date = Date.strptime("#{year}-#{1}", "%Y-%W")
+			when 53
+				@date = Date.strptime("#{year}-#{52}", "%Y-%W")
+			when 54
+				year += 1
+				week = 0
+				retry
+			end
+		end
+
+		def year
+			@year ||= Year.new(year: @date.year)
 		end
 
 		def number
-			@date.cweek
+			@date.strftime("%W").to_i
 		end
 
 		def <=>(other)
-			number <=> other.number
+			case year <=> other.year
+			when -1
+				-1
+			when 0
+				number <=> other.number
+			when 1
+				1
+			end
 		end
 
 		def succ

--- a/lib/playdate/week.rb
+++ b/lib/playdate/week.rb
@@ -3,6 +3,7 @@ module Playdate
 		include Relative::Weeks
 		include Relative::Months
 		include Relative::Years
+		include Comparable
 
 		def initialize(year:, week:)
 			@date = Date.strptime("#{year}-#{week}", "%Y-%W")

--- a/lib/playdate/year.rb
+++ b/lib/playdate/year.rb
@@ -57,11 +57,11 @@ module Playdate
 		end
 
 		def first_week
-			Week.new(year: @date.year, week: 1)
+			Week.new(year: @date.year, week: 0)
 		end
 
 		def last_week
-			Week.new(year: @date.year, week: -1)
+			Week.new(year: @date.year, week: number_of_weeks)
 		end
 
 		def first_day
@@ -72,6 +72,12 @@ module Playdate
 		def last_day
 			date = Date.new(@date.year, 12, -1)
 			Day.new(year: date.year, month: date.month, day: date.day)
+		end
+
+		def number_of_weeks
+			@date.step(Date.new(@date.year,-1,-1)).select do |day|
+				day.monday?
+			end.size
 		end
 	end
 end

--- a/test/playdate/week_test.rb
+++ b/test/playdate/week_test.rb
@@ -1,0 +1,30 @@
+require "playdate"
+
+describe Playdate::Week do
+	let(:week_53_of_2001) { Playdate::Week.new(year: 2001, week: 53) }
+	let(:week_1_of_2002) { Playdate::Week.new(year: 2002, week: 1) }
+	let(:week_0_of_2022) { Playdate::Week.new(year: 2022, week: 0) }
+	let(:week_1_of_2022) { Playdate::Week.new(year: 2022, week: 1) }
+	let(:week_52_of_2022) { Playdate::Week.new(year: 2022, week: 52) }
+	let(:week_53_of_2022) { Playdate::Week.new(year: 2022, week: 53) }
+	let(:week_54_of_2022) { Playdate::Week.new(year: 2022, week: 54) }
+	let(:week_1_of_2023) { Playdate::Week.new(year: 2023, week: 1) }
+
+	class << self
+		alias_method :test, :it
+	end
+
+	test "new" do
+		expect(week_0_of_2022).to be == week_1_of_2022
+		expect(week_53_of_2022).to be == week_52_of_2022
+		expect(week_54_of_2022).to be == week_1_of_2023
+	end
+
+	test "<=>" do
+		expect(week_53_of_2001 <=> week_1_of_2002).to be == -1
+	end
+
+	test "succ" do
+		expect(week_53_of_2001.succ).to be == week_1_of_2002
+	end
+end


### PR DESCRIPTION
Improvements:
- Uses `Date.strptime` to get a date from a week number
- `#<=>` takes the year into account
- `#succ` can return the first week of the next year

Additions:
- `Playdate::Year#number_of_weeks`